### PR TITLE
InjectController.Event implemented as separate middleware. Updated NETCoreApp to 1.1.0.

### DIFF
--- a/test/Prometheus.Demo/InjestEventsMiddleware.cs
+++ b/test/Prometheus.Demo/InjestEventsMiddleware.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Prometheus.Demo.Controllers;
+
+namespace Prometheus.Demo
+{
+    public class InjestEventsMiddleware
+    {
+        private readonly HttpClient _client = new HttpClient(new HttpClientHandler
+        {
+            MaxConnectionsPerServer = int.MaxValue,
+            UseProxy = false, // Perf sensitive
+            UseCookies = false
+        });
+
+        private readonly Uri _proxyEndpointUri;
+
+        private readonly JsonSerializer _serializer = new JsonSerializer();
+
+        public InjestEventsMiddleware(RequestDelegate next, IOptions<Settings> settings)
+        {
+            if (!string.IsNullOrEmpty(settings.Value.ProxyFor))
+            {
+                _proxyEndpointUri = new Uri(settings.Value.ProxyFor + "/ingest/data");
+            }
+        }
+
+        public async Task Invoke(HttpContext httpContext)
+        {
+            if (_proxyEndpointUri == null)
+                return;
+
+            Payload payload;
+            using (var sr = new StreamReader(httpContext.Request.Body, Encoding.UTF8))
+            {
+                payload = (Payload) _serializer.Deserialize(sr, typeof(Payload));
+            }
+
+            if (string.IsNullOrEmpty(payload.Data))
+            {
+                return;
+            }
+
+            var data = JsonConvert.DeserializeObject<dynamic>(payload.Data);
+
+            using (var message = new HttpRequestMessage(HttpMethod.Post, _proxyEndpointUri))
+            {
+                message.Content = new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json");
+
+                using (var response = await _client.SendAsync(message))
+                {
+                    response.EnsureSuccessStatusCode();
+                }
+            }
+        }
+    }
+
+    public static class InjestEventsMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseInjestEventsMiddleware(this IApplicationBuilder builder)
+        {
+            builder
+                .Map("/injest/event", app => app.UseMiddleware<InjestEventsMiddleware>());
+            return builder;
+        }
+    }
+}

--- a/test/Prometheus.Demo/Startup.cs
+++ b/test/Prometheus.Demo/Startup.cs
@@ -61,6 +61,8 @@ namespace Prometheus.Demo
 
             //app.UseDeveloperExceptionPage();
 
+            app.UseInjestEventsMiddleware();
+
             app.UsePrometheusMiddleware();
 
             app.UseStaticFiles();

--- a/test/Prometheus.Demo/project.json
+++ b/test/Prometheus.Demo/project.json
@@ -1,26 +1,26 @@
 {
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.1",
+      "version": "1.1.0",
       "type": "platform"
     },
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
-    "Microsoft.AspNetCore.Mvc": "1.0.1",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "1.0.0-preview2-final",
       "type": "build"
     },
-    "Microsoft.AspNetCore.Routing": "1.0.1",
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
-    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
-    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0",
-    "Microsoft.Extensions.Logging": "1.0.0",
-    "Microsoft.Extensions.Logging.Console": "1.0.0",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0",
-    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0",
-    "Prometheus.AspNetCore": "1.0.0-*"
+    "Prometheus.AspNetCore": "1.0.0-*",
+    "Microsoft.AspNetCore.Routing": "1.1.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
+    "Microsoft.AspNetCore.StaticFiles": "1.1.0",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.0",
+    "Microsoft.Extensions.Configuration.Json": "1.1.0",
+    "Microsoft.Extensions.Logging": "1.1.0",
+    "Microsoft.Extensions.Logging.Console": "1.1.0",
+    "Microsoft.Extensions.Logging.Debug": "1.1.0",
+    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.0",
+    "Microsoft.AspNetCore.Diagnostics": "1.1.0",
+    "Microsoft.AspNetCore.Mvc": "1.1.1"
   },
 
   "tools": {
@@ -42,7 +42,7 @@
 
   "runtimeOptions": {
     "configProperties": {
-      "System.GC.Server": false
+      "System.GC.Server": true
     }
   },
 


### PR DESCRIPTION
Added middleware that will handle specific path to preserve existing code.
As for GC mode, maybe 1.1.0 will be less buggy on Linux. Also it is possible to try Concurrent mode. Anyway without Server GC perf is very mediocre. This are results on my machine. Maybe JIL json serializer will also improve overall perf.

![capture](https://cloud.githubusercontent.com/assets/557594/23035969/2723695a-f492-11e6-94e5-07c3c49fafd5.PNG)


Test data was because of mismatch of doc and model in code.
```
{
    "Data": "{'Data':'mock data'}"
}
```

